### PR TITLE
fix: profile card centered on mobile view

### DIFF
--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -5,7 +5,7 @@ import { basePath } from "../util/helper";
 export default function OverviewCard({ profile }: { profile: ProfileType }) {
   return (
     <Link href={`/${profile.username}`}>
-      <div className="my-4 mx-auto flex w-full cursor-pointer flex-col rounded-lg bg-white p-4 transition-all hover:shadow-xl">
+      <div className="my-4 mx-auto flex w-full cursor-pointer flex-col rounded-lg bg-white p-4 transition-all hover:shadow-xl ">
         <div className="text-400 flex items-center text-lg font-semibold">
           <a
             target="_blank"

--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -5,7 +5,7 @@ import { basePath } from "../util/helper";
 export default function OverviewCard({ profile }: { profile: ProfileType }) {
   return (
     <Link href={`/${profile.username}`}>
-      <div className="m-4 flex w-full cursor-pointer flex-col rounded-lg bg-white p-4 transition-all hover:shadow-xl">
+      <div className="my-4 mx-auto flex w-full cursor-pointer flex-col rounded-lg bg-white p-4 transition-all hover:shadow-xl">
         <div className="text-400 flex items-center text-lg font-semibold">
           <a
             target="_blank"

--- a/components/overview-card.tsx
+++ b/components/overview-card.tsx
@@ -4,7 +4,7 @@ import { basePath } from "../util/helper";
 export default function OverviewCard({ profile }: { profile: ProfileType }) {
   return (
     <a href={`${basePath}/${profile.username}`}>
-      <div className="m-4 flex w-full cursor-pointer flex-col rounded-lg bg-white p-4 transition-all hover:shadow-xl">
+      <div className="m-4 flex w-full cursor-pointer flex-col rounded-lg bg-white p-4 transition-all hover:shadow-xl border-8 border-sky-500">
         <div className="text-400 flex items-center text-lg font-semibold">
           <a
             target="_blank"


### PR DESCRIPTION
Issue: #142 - Right side padding/margin bug on mobile phones

- https://github.com/FitDevs-withKat/Fitness-Accountability/issues/142

Description: 

- kept margin of 4 in the y-axis, `my-4` 
- added margin of auto to x-axis `mx-auto`

Screenshots: 
![desktop-screenshot](https://user-images.githubusercontent.com/38892213/183248658-ee479f75-9e4d-4b48-8253-b2ba37b34e2a.png)
![mobile-screenshot](https://user-images.githubusercontent.com/38892213/183248662-4d198b97-d578-4b92-9506-ce48e93b660c.png)
![tablet-screenshot](https://user-images.githubusercontent.com/38892213/183248663-9aed725f-f04a-45f8-96fb-700449410547.png)