### PR TITLE
fix: remove next/image

### DIFF
--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import { ProfileType } from "../types/ProfileType";
 import { basePath } from "../util/helper";
-import Image from 'next/image'
 
 export default function OverviewCard({ profile }: { profile: ProfileType }) {
   return (
@@ -11,7 +10,7 @@ export default function OverviewCard({ profile }: { profile: ProfileType }) {
           <a
             target="_blank"
             rel="noreferrer"
-            className="transition-all delay-75 duration-200 hover:underline"
+            className="dely-75 transition-all duration-200 hover:underline"
             href={profile.url}
           >
             {profile.name}
@@ -20,11 +19,13 @@ export default function OverviewCard({ profile }: { profile: ProfileType }) {
         </div>
 
         <div className="mt-4">
-          <Image
-            alt="SVG of Location Pointer"
-            className="location-icon"
-            src={`${basePath}/location.svg`}
-          />
+          <picture>
+            <img
+              className="location-icon"
+              alt="SVG of Location Pointer"
+              src={`${basePath}/location.svg`}
+            />
+          </picture>
           {profile.location}
         </div>
         <div className="mt-4">

--- a/components/overview-card.tsx
+++ b/components/overview-card.tsx
@@ -1,11 +1,10 @@
 import { ProfileType } from "../types/ProfileType";
 import { basePath } from "../util/helper";
-import Image from 'next/image'
 
 export default function OverviewCard({ profile }: { profile: ProfileType }) {
   return (
     <a href={`${basePath}/${profile.username}`}>
-      <div className="m-4 flex w-full cursor-pointer flex-col rounded-lg bg-white p-4 transition-all hover:shadow-xl border-8 border-sky-500">
+      <div className="m-4 flex w-full cursor-pointer flex-col rounded-lg border-8 border-sky-500 bg-white p-4 transition-all hover:shadow-xl">
         <div className="text-400 flex items-center text-lg font-semibold">
           <a
             target="_blank"
@@ -19,11 +18,13 @@ export default function OverviewCard({ profile }: { profile: ProfileType }) {
         </div>
 
         <div className="mt-4">
-          <Image
-            className="location-icon"
-            alt="SVG of Location Pointer"
-            src={`${basePath}/location.svg`}
-          />
+          <picture>
+            <img
+              className="location-icon"
+              alt="SVG of Location Pointer"
+              src={`${basePath}/location.svg`}
+            />
+          </picture>
           {profile.location}
         </div>
         <div className="mt-4">

--- a/components/profile_detail/personal-card.tsx
+++ b/components/profile_detail/personal-card.tsx
@@ -1,16 +1,17 @@
 import { ProfileType } from "../../types/ProfileType";
-import Image from 'next/image'
 
 export default function ProfileDetail({ profile }: { profile: ProfileType }) {
   return (
     <aside className="flex flex-col items-center rounded-xl bg-white p-8 shadow-lg">
-      <Image
-        alt={`profile picture of ${profile.name}`}
-        className="rounded-full"
-        height={150}
-        width={150}
-        src={profile.image}
-      />
+      <picture>
+        <img
+          alt={`profile picture of ${profile.name}`}
+          className="rounded-full"
+          height={150}
+          width={150}
+          src={profile.image}
+        />
+      </picture>
       <h1 className="my-1 text-xl font-bold leading-8 text-gray-900">
         <a
           target="_blank"


### PR DESCRIPTION
This addresses issue: https://github.com/FitDevs-withKat/Fitness-Accountability/issues/177

This will fix two errors which were introduced when using the `next/image` component. I've reverted the component due to some limitation I saw when debugging the pages that were broken on the landing and profile pages. 

Please read the issue I opened for more context: https://github.com/FitDevs-withKat/Fitness-Accountability/issues/177

#### Side note
I'd recommend when reviewing pull requests by pulling down the code/branch and try to run it locally to properly check the feature before merging them, you never know what changes can bring down the site if we're not careful

## The first error:
![Screenshot 2022-08-15 214839](https://user-images.githubusercontent.com/4426088/184723033-0d54352a-fffb-4b90-ac77-3c4ebcf3c960.jpg)

## And the second error: 
![Screenshot 2022-08-15 221205](https://user-images.githubusercontent.com/4426088/184723054-2e49ffb6-9d46-4109-bb66-43917ede85fc.jpg)
![Screenshot 2022-08-15 214839](https://user-images.githubusercontent.com/4426088/184723058-5ad29647-c991-4662-805d-111fb6279524.jpg)


